### PR TITLE
Fix events archive layout (#9)

### DIFF
--- a/events/templates/events/events_archive_page.html
+++ b/events/templates/events/events_archive_page.html
@@ -16,52 +16,48 @@
                     {% if weeks %}
                         <div class="block">
                             {% for week in weeks %}
-                                <div>
-                                    <div class="tile is-ancestor is-vertical">
-                                        <div class="tile is-parent is-vertical">
-                                            <div class="tile is-child notification is-dark">
-                                                <h5 class="subtitle">Week beginning {{ week.0.start|first_monday|date:'jS F Y' }} </h5>
-                                            </div>
+                                <div class="tile is-ancestor is-vertical">
+                                    <div class="tile is-parent is-vertical py-0">
+                                        <div class="tile is-child notification is-dark box">
+                                            <h5 class="subtitle">Week beginning {{ week.0.start|first_monday|date:'jS F Y' }} </h5>
                                         </div>
-                                        {% for event in week %}
-                                                <div class="tile is-parent is-vertical">
-                                                <div class="tile is-child is-vertical notification {% if event.is_ongoing %}is-primary-light-scheme{% elif event.cancelled %}is-cancelled-scheme{% else %}is-light-scheme{% endif %}">
-                                                        <div class="event-content">
-                                                            <div class="columns is-vcentered">
-                                                                <div class="column is-vcentered">
-                                                                    <h3 class="title is-4">{{ event.title }}</h3>
-                                                                    {% if event.is_ongoing %}
-                                                                        <small class="mb-3"><strong>Event is in progress</strong></small>
-                                                                    {% elif event.cancelled %}
-                                                                        <small class="mb-3"><strong>Event has been cancelled</strong></small>
-                                                                    {% endif %}
-                                                                    {% if event.signup_type != 0 %}
-                                                                        <h6 class="mb-4">Signup required {% if event.sighup_type == 2 %}via external link{% endif %}</h6>
-                                                                        {% if event.signup_limit > 0 %}
-                                                                            <small class="mb-3">Signups: {{ event.signups.count }}/{{ event.signup_limit }}</small>
-                                                                        {% endif %}
-                                                                    {% endif %}
-                                                                </div>
-                                                                <div class="column">
-                                                                        <p class="icon-line">
-                                                                            <i class="fas fa-clock fa-fw icon-lead"></i>
-                                                                            <span class="icon-text">{{ event.start|date:'H:i, D jS F' }}-{{ event.finish|date:'H:i, D jS F' }}</span>
-                                                                        </p>
-                                                                        <p class="icon-line">
-                                                                            <i class="fas fa-map-marker-alt fa-fw icon-lead"></i>
-                                                                            <span class="icon-text">{{ event.location }}</span>
-                                                                        </p>
-                                                                        <br>
-                                                                        <p>{{ event.description }}</p>
-                                                                    <br>
-                                                                    <a class="button is-right {% if event.is_ongoing == False and event.cancelled == False %}is-primary{% endif %}" href="{% pageurl event %}">Learn more&nbsp;<i class="fas fa-chevron-right"></i></a>
-                                                                </div>
-                                                            </div>
-                                                        </div>
+                                    </div>
+                                    {% for event in week %}
+                                        <div class="tile is-parent is-vertical py-0">
+                                            <div class="tile is-child is-vertical notification {% if event.is_ongoing %}is-primary-light-scheme{% elif event.cancelled %}is-cancelled-scheme{% else %}is-light-scheme{% endif %} box">
+                                                <div class="columns is-vcentered">
+                                                    <div class="column is-vcentered">
+                                                        <h3 class="title is-4">{{ event.title }}</h3>
+                                                        {% if event.is_ongoing %}
+                                                            <small class="mb-3"><strong>Event is in progress</strong></small>
+                                                        {% elif event.cancelled %}
+                                                            <small class="mb-3"><strong>Event has been cancelled</strong></small>
+                                                        {% endif %}
+                                                        {% if event.signup_type != 0 %}
+                                                            <h6 class="mb-4">Signup required {% if event.sighup_type == 2 %}via external link{% endif %}</h6>
+                                                            {% if event.signup_limit > 0 %}
+                                                                <small class="mb-3">Signups: {{ event.signups.count }}/{{ event.signup_limit }}</small>
+                                                            {% endif %}
+                                                        {% endif %}
+                                                    </div>
+                                                    <div class="column">
+                                                            <p class="icon-line">
+                                                                <i class="fas fa-clock fa-fw icon-lead"></i>
+                                                                <span class="icon-text">{{ event.start|date:'H:i, D jS F' }} - {{ event.finish|date:'H:i, D jS F' }}</span>
+                                                            </p>
+                                                            <p class="icon-line">
+                                                                <i class="fas fa-map-marker-alt fa-fw icon-lead"></i>
+                                                                <span class="icon-text">{{ event.location }}</span>
+                                                            </p>
+                                                            <br>
+                                                            <p>{{ event.description }}</p>
+                                                        <br>
+                                                        <a class="button is-right {% if event.is_ongoing == False and event.cancelled == False %}is-primary{% endif %}" href="{% pageurl event %}">Learn more&nbsp;<i class="fas fa-chevron-right"></i></a>
+                                                    </div>
                                                 </div>
                                             </div>
-                                        {% endfor %}
-                                    </div>
+                                        </div>
+                                    {% endfor %}
                                 </div>
                                 <br />
                             {% endfor %}


### PR DESCRIPTION
Layout now matches that of the events index page (https://uwcs.co.uk/events, I just copied the template :P), closes #9 