### PR TITLE
Slightly adjust dropdown click trigger

### DIFF
--- a/lib/templates/lib/tags/top_menu.html
+++ b/lib/templates/lib/tags/top_menu.html
@@ -29,7 +29,7 @@
 
             <div class="navbar-end">
                 {% if request.user.is_authenticated %}
-                    <div class="navbar-item has-dropdown is-hoverable" id="userDropdown">
+                    <div class="navbar-item has-dropdown is-hoverable user-dropdown">
                         <a class="navbar-link">
                             {% if request.user.compsocuser %}
                                 {{ request.user.compsocuser }}

--- a/static/js/core.js
+++ b/static/js/core.js
@@ -8,9 +8,10 @@ $(document).ready(function() {
 
   });
 
-  $("#userDropdown").click(function() {
-      // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
-      $("#userDropdown").toggleClass("is-active");
+  // Check for click events on the user profile dropdown
+  $(".user-dropdown").click(function() {
+      // Toggle the "is-active" class on the "user-dropdown" class
+      $(".user-dropdown").toggleClass("is-active");
 
   });
 });


### PR DESCRIPTION
Moves to using a class instead of ID for trigger, also updates comments as I forgot to update those originally...

I don't think this fixes the issue of not being able to close the dropdown on non-hover-compatible browsers (e.g. Safari on iPad) but tbh I don't understand that one :D