### PR TITLE
Generate HTML for email from a blog page

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -352,6 +352,7 @@ class BlogPage(Page):
         context['email'] = render_to_string('email_base.html', html_context)
         context['email'] = context['email'].replace("class=\"richtext-image left\"", "")
         context['email'] = context['email'].replace("<p></p>", "")
+        context['email'] = context['email'].replace("class=\"bs-callout\"", "")
         return context
 
 

--- a/blog/models.py
+++ b/blog/models.py
@@ -2,6 +2,7 @@ import copy
 from datetime import datetime
 from django.core.paginator import PageNotAnInteger, EmptyPage
 from django.db import models
+from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 from modelcluster.contrib.taggit import ClusterTaggableManager
@@ -344,6 +345,13 @@ class BlogPage(Page):
     def get_context(self, request):
         context = super(BlogPage, self).get_context(request)
         context['body'] = self.body
+        html_context = {
+            'title': self.title,
+            'content': self.body
+        }
+        context['email'] = render_to_string('email_base.html', html_context)
+        context['email'] = context['email'].replace("class=\"richtext-image left\"", "")
+        context['email'] = context['email'].replace("<p></p>", "")
         return context
 
 

--- a/blog/templates/blog/blog_page.html
+++ b/blog/templates/blog/blog_page.html
@@ -11,7 +11,6 @@
             <div class="columns">
                 <div class="column">
                     <article>
-
                         <h1 class="title has-2 mb-2">{{ self.title }}</h1>
                         {% if self.tags %}
                             <div class="tags mb-0">
@@ -27,10 +26,75 @@
                     </article>
                 </div>
                 <div class="column is-one-third-tablet is-one-quarter-desktop is-one-fifth-fullhd">
+                    {% if request.user.is_staff %}
+                        <button class="button is-primary modal-button" id="emailHTMLButton"
+                                data-toggle="#email-html-modal">
+                            Generate email HTML
+                        </button>
+                    {% endif %}
                     {% blog_sidebar %}
                     {% sponsor_sidebar %}
                 </div>
             </div>
         </div>
     </section>
+
+    <div class="modal" id="email-html-modal">
+        <div class="modal-background"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">Email HTML</p>
+                <button class="delete modal-close" aria-label="close"></button>
+            </header>
+            <section class="modal-card-body">
+                <div class="code-block email-html" id="email-html">
+                    {{ email|safe }}
+                </div>
+            </section>
+            <footer class="modal-card-foot">
+                <button class="button modal-button copy" id="email-html-button">Copy to clipboard
+                </button>
+            </footer>
+        </div>
+    </div>
 {% endblock content %}
+
+{% block extra_js %}
+    <script type="text/javascript">
+        // copy code to clipboard
+        new ClipboardJS('.copy', {
+            text: function() {
+                // based on your fiddle, you may need to replace this selector, too.
+                var htmlBlock = document.querySelector('.email-html');
+                return htmlBlock.innerHTML;
+            }
+        });
+
+        // JS to open/close modal
+        const modal =
+            document.querySelector('#email-html-modal');
+        const btn =
+            document.querySelector('#emailHTMLButton')
+        const close =
+            document.querySelector('.modal-close')
+
+        btn.addEventListener('click',
+            function () {
+                modal.style.display = 'block'
+            })
+
+        close.addEventListener('click',
+            function () {
+                modal.style.display = 'none'
+            })
+
+        window.addEventListener('click',
+            function (event) {
+                if (event.target.className ===
+                    'modal-background') {
+                    modal.style.display = 'none'
+                }
+            })
+
+    </script>
+{% endblock %}

--- a/blog/templates/blog/blog_page.html
+++ b/blog/templates/blog/blog_page.html
@@ -64,7 +64,6 @@
         // copy code to clipboard
         new ClipboardJS('.copy', {
             text: function() {
-                // based on your fiddle, you may need to replace this selector, too.
                 var htmlBlock = document.querySelector('.email-html');
                 return htmlBlock.innerHTML;
             }

--- a/dextre/templates/email_base.html
+++ b/dextre/templates/email_base.html
@@ -1,0 +1,45 @@
+<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6; margin: 0; padding: 0; line-height: 1.4;">
+	<tbody>
+		<tr>
+			<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+			<td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 1000px; padding: 10px; min-width: 320px;overflow-wrap: break-word;word-break:break-word">
+			<div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 1000px; padding: 10px; min-width: 320px;">
+			<table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 3px;">
+				<tbody>
+					<tr>
+						<td class="wrapper" style="font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 20px;">
+						<table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+							<tbody>
+								<tr>
+									<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+									<div style="border:0; outline:none; text-decoration:none; display:flex; text-align: center; margin-left: auto; margin-right: auto; align-items: center; justify-content: center;"><img alt="UWCS Shield" border="0" height="60" src="https://uwcs.co.uk/media/images/shield.original.png" style="border:0; outline:none; text-decoration:none; display:inline-block; text-align: center; margin-left: 0; margin-right: auto; align-items: center; justify-content: center;" />
+									<h3 style="display:inline-block; vertical-align: middle; align-items: center; justify-content: center;"><strong>{{ title }}</strong></h3>
+									</div>
+
+									<hr />
+									{{ content }}
+									</td>
+								</tr>
+							</tbody>
+						</table>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<div class="footer" style="clear: both; Margin-top: 10px; text-align: center; width: 100%;">
+			<table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+				<tbody>
+					<tr>
+						<td class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; color: #999999; text-align: center;"><span class="apple-link" style="color: #999999; font-size: 12px; text-align: center;">University of Warwick Computing Society</span><br />
+						<a href="https://www.uwcs.co.uk/" style="text-decoration: underline; color: #999999; font-size: 12px; text-align: center;">https://www.uwcs.co.uk/</a>.</td>
+					</tr>
+				</tbody>
+			</table>
+			</div>
+			</div>
+			</td>
+			<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+		</tr>
+	</tbody>
+</table>

--- a/dextre/templates/new_base.html
+++ b/dextre/templates/new_base.html
@@ -81,6 +81,7 @@
 {% compress js %}
     <script type="text/javascript" src="{% static 'js/core.js' %}"></script>
 {% endcompress %}
+<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.8/dist/clipboard.min.js"></script>
 <script type="text/javascript">
 
     // Set jQuery XHR header for CSRF requests


### PR DESCRIPTION
Adds a button to the sidebar for exec/"staff" users on "blog" pages on the website that provides the HTML layout for emails that can then be copied into the SU email system. Removes any classes that mess up email layout, and fixed image width to the correct width for sending out.
Feature also works on "preview" pages in Wagtail, so can be used on non-published pages. This could be useful for sending out things like announcements/one-off emails that do not necessarily need a post on the website.